### PR TITLE
Update to v0.6.0.0 

### DIFF
--- a/nuget-sources.json
+++ b/nuget-sources.json
@@ -26,5 +26,19 @@
         "sha512": "bc7d22c8d198304d695ee9ae5ed4c9dbd01028f2b4ce11c3ee70d072d006802eed21712840301aad3edae5f67685f52d69b76f679ea23ba2384dfb27187b419e",
         "dest": "nuget-sources",
         "dest-filename": "sharpdl-sdl2-cs.1.0.13.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/zlinq/1.5.6/zlinq.1.5.6.nupkg",
+        "sha512": "bea8321ca55a2b4603783568e8b1a1e733770818bf308bcdda3a27b81497fff64e3226742223b01855466df60df58c41ffec5e91f7aa0bedf0ae2f89c86c570c",
+        "dest": "nuget-sources",
+        "dest-filename": "zlinq.1.5.6.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/zlinq.dropingenerator/1.5.6/zlinq.dropingenerator.1.5.6.nupkg",
+        "sha512": "a34ac817aec16542784067101be7d4abf694e9b34b7868108e4ee0c605b99b1a32df45fc30c0cc3fd268ccebb6ac921a3a064d11e26eda2bf6630718ac097288",
+        "dest": "nuget-sources",
+        "dest-filename": "zlinq.dropingenerator.1.5.6.nupkg"
     }
 ]

--- a/nuget-sources.json
+++ b/nuget-sources.json
@@ -8,24 +8,10 @@
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/keralua/1.4.4/keralua.1.4.4.nupkg",
-        "sha512": "4daa09e8ed230dd1784eee210fe6324d24277027560024d69f031a8edb560a9e01085b8d069a1c9f5fa50b34001aa378184c0224caf5247418a827562ed5e123",
-        "dest": "nuget-sources",
-        "dest-filename": "keralua.1.4.4.nupkg"
-    },
-    {
-        "type": "file",
         "url": "https://api.nuget.org/v3-flatcontainer/microsoft.net.illink.tasks/8.0.24/microsoft.net.illink.tasks.8.0.24.nupkg",
         "sha512": "e5d8213656a1b53bafc6c2bed19107bae7e3138a7f3ab5441db1a468d2d9ecc5bc1bb02780c3d66465971ac0b7060decdb3b067618fa564cd01d9f2e4b84bac8",
         "dest": "nuget-sources",
         "dest-filename": "microsoft.net.illink.tasks.8.0.24.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/nlua/1.7.5/nlua.1.7.5.nupkg",
-        "sha512": "ffe32b221ccee3c30b7b3fbd9cb81cbdc0397ab1b8e3d4ccd6e796c195996362499a1cb96f89bc185ace16d4e0be347eaa6619fe3ed8cdc441130246c3be8544",
-        "dest": "nuget-sources",
-        "dest-filename": "nlua.1.7.5.nupkg"
     },
     {
         "type": "file",

--- a/nuget-sources.json
+++ b/nuget-sources.json
@@ -8,10 +8,10 @@
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.net.illink.tasks/8.0.24/microsoft.net.illink.tasks.8.0.24.nupkg",
-        "sha512": "e5d8213656a1b53bafc6c2bed19107bae7e3138a7f3ab5441db1a468d2d9ecc5bc1bb02780c3d66465971ac0b7060decdb3b067618fa564cd01d9f2e4b84bac8",
+        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.net.illink.tasks/8.0.26/microsoft.net.illink.tasks.8.0.26.nupkg",
+        "sha512": "448813b119c2659487ebd0bfb977f33edcef740a2176cb52e85e61db3e4f22c1404ec4a3b185d0d0d97524b3bed4b2310e26b210eb2a67ac8acfc046540a5fe9",
         "dest": "nuget-sources",
-        "dest-filename": "microsoft.net.illink.tasks.8.0.24.nupkg"
+        "dest-filename": "microsoft.net.illink.tasks.8.0.26.nupkg"
     },
     {
         "type": "file",

--- a/us.acei.AbsoluteInfinity.yaml
+++ b/us.acei.AbsoluteInfinity.yaml
@@ -32,7 +32,7 @@ modules:
     sources:
       - type: archive
         url: https://gitlab.com/acei.us/games/project4/game/-/archive/v0.6.0.0-alpha/game-v0.6.0.0-alpha.zip
-        sha256: 72581882aec001960e4b67671132ac619819663f7af866164d07c9db13d11d2a
+        sha256: 451d215d3fc9ca1cf3f928a6989e0a0113cc0022c2bd13c00a3694650a9e5894
       # Generated with https://raw.githubusercontent.com/flatpak/flatpak-builder-tools/master/dotnet/flatpak-dotnet-generator.py
       - ./nuget-sources.json
     build-options:

--- a/us.acei.AbsoluteInfinity.yaml
+++ b/us.acei.AbsoluteInfinity.yaml
@@ -31,8 +31,8 @@ modules:
     buildsystem: simple
     sources:
       - type: archive
-        url: https://gitlab.com/acei.us/games/project4/game/-/archive/v0.6.0.0-alpha/game-v0.6.0.0-alpha.zip
-        sha256: 451d215d3fc9ca1cf3f928a6989e0a0113cc0022c2bd13c00a3694650a9e5894
+        url: https://gitlab.com/acei.us/games/project4/game/-/archive/v0.6.0.0/game-v0.6.0.0.zip
+        sha256: 1a76092df5eb379685a2984e1342ceb61bf672880cb1364497b9e649a02b45dc
       # Generated with https://raw.githubusercontent.com/flatpak/flatpak-builder-tools/master/dotnet/flatpak-dotnet-generator.py
       - ./nuget-sources.json
     build-options:

--- a/us.acei.AbsoluteInfinity.yaml
+++ b/us.acei.AbsoluteInfinity.yaml
@@ -31,8 +31,8 @@ modules:
     buildsystem: simple
     sources:
       - type: archive
-        url: https://gitlab.com/acei.us/games/project4/game/-/archive/v0.5.11.0/game-v0.5.11.0.zip
-        sha256: d614ebe8c34459e7c054042e4f1f41d697188053dcb0e2cdf4e909fa0f255411
+        url: https://gitlab.com/acei.us/games/project4/game/-/archive/v0.6.0.0-alpha/game-v0.6.0.0-alpha.zip
+        sha256: 72581882aec001960e4b67671132ac619819663f7af866164d07c9db13d11d2a
       # Generated with https://raw.githubusercontent.com/flatpak/flatpak-builder-tools/master/dotnet/flatpak-dotnet-generator.py
       - ./nuget-sources.json
     build-options:


### PR DESCRIPTION

- Add "Integrity" as a possible name for NPC ships
- Add gamedata editor to public game files
- Add procedural mission system
    - Add "Jobs" page to space stations
    - Add delivery missions
    - Add mining missions
- Add new codex entries
    - Added tutorials for new mission types
    - Added new lore entries & revised old ones
- Add new splash screen
- Add new win screen
- Add flash on top-right hint
- Add option to rebind quicksave and quickload
- Add button to hide tutorial hints
- Add sound effects to some UI interactions
- Add button to align ship with cursor
- Add "Sheild Down!" notification
- Add "Hull Critical!" notification
- Changed HUD layout to be more readable
- Increased asteroid friction
- Changed scanner font color to be bolder
- Changed scanner to show (You) on label for your ship
- Re-labeled Inventory button in station to Market & Inventory
- Switch to a zero-allocation LINQ provider (should speed up nearly everything)
- The journal now shows the map tabs above it
- The selected mission in the journal is now considered the 'active' mission
- Fix bug with inventory panel not updating
- Fix bug where $0 transactions appear in wallet
- Fix console getting clogged with messages even after `clear` was run
- Fix mouse cursor not changing when buttons are hovered (only took me a year to notice)
- Fix fading-out effect blocking pause screen if opened
- Fix quest names bleeding out of journal
- Fix messages from NPC ships appearing in the player's message queue
- Fix typos in hints and dialogue
- Fix bug where corrupted/malformed preferences.json files would crash the game during startup
- Fix "Emergency Stopped!" message appearing during standard jaunt stops
- Fix system exploration status not being saved
- Fix being unable to jaunt with map open
- Fix starmaps not resizing properly
- Fix dead ships respawning when reloading saves
- Fix torpedos not getting shot down by slugs
- Potential fix planet positions being NaN (ghost planets)
- Potential fix for linebreaks being multiplied on windows
- Remove faction display from new game menu (no longer an option)

Your settings will reset when playing this version for the first time.